### PR TITLE
Make output great again

### DIFF
--- a/lib/widgets/KeyBar.js
+++ b/lib/widgets/KeyBar.js
@@ -4,16 +4,18 @@ const clc = require('cli-color');
 const gauge = CLI.Gauge;
 const Line = CLI.Line;
 
-module.exports = function (tactile, max) {
+module.exports = function (tactile, maxIdLength, max) {
 	if (!tactile) {
 		return new Line();
 	}
+	let id = Array(maxIdLength - tactile.id.toString().length).join(0) + tactile.id.toString();
 	let name = tactile.label;
 	if (tactile.name) {
 		name += ` (${tactile.name.toUpperCase()})`;
 	}
 	return new Line()
 		.padding(2)
+		.column(id, 5, [clc.magenta])
 		.column(name, 15, [clc.cyan])
 		.column(gauge(tactile.percentHolding * 100, max, 20, 60), 25)
 		.column(gauge(tactile.percentReleasing * 100, max, 20, 60), 25)

--- a/lib/widgets/KeyBar.js
+++ b/lib/widgets/KeyBar.js
@@ -15,7 +15,7 @@ module.exports = function (tactile, maxIdLength, max) {
 	}
 	return new Line()
 		.padding(2)
-		.column(id, 5, [clc.magenta])
+		.column(id, maxIdLength + 3, [clc.magenta])
 		.column(name, 15, [clc.cyan])
 		.column(gauge(tactile.percentHolding * 100, max, 20, 60), 25)
 		.column(gauge(tactile.percentReleasing * 100, max, 20, 60), 25)

--- a/lib/widgets/index.js
+++ b/lib/widgets/index.js
@@ -18,6 +18,8 @@ function flattenQGram(qgram) {
 	return flattened;
 }
 module.exports = function (report) {
+	const tactileArray = util.convertToArray(report.tactile);
+	const maxIdLength = Math.floor(Math.log10(Math.abs(tactileArray.length))) + 1;
 	const blankLine = new Line().fill().output();
 	const base = new LineBuffer();
 	base.addLine(blankLine);
@@ -25,12 +27,13 @@ module.exports = function (report) {
 	base.addLine(blankLine);
 	const labels = new Line()
 	.padding(2)
+	.column('ID', maxIdLength + 3)
 	.column('Key', 20)
-	.column('Holding %', 27)
+	.column('Holding %', 25)
 	.column('Releasing %', 27);
 	base.addLine(labels);
-	util.convertToArray(report.tactile).forEach(tactile => {
-		base.addLine(keyBar(tactile, 100));
+	tactileArray.sort(function(a, b) { return a.id - b.id; }).forEach(tactile => {
+		base.addLine(keyBar(tactile, maxIdLength, 100));
 	});
 	const now = new Date().toLocaleString();
 	base.addLine(new Line().padding(2).column(`Last Control Update:${now}`, 50).fill());

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "beam-interactive-node": "^0.3.1",
     "bluebird": "^3.4.1",
     "cli-color": "^1.1.0",
-    "clui": "^0.3.1",
+    "clui": "git://github.com/metaa/clui",
     "deep-equal": "^1.0.1",
     "keycode": "^2.1.0",
     "robot-js": "^1.0.2"


### PR DESCRIPTION
This sorts the tactiles by id so that the keys don't randomly jump around on the output list with the gauges.
Also it adds the ids to the output for debugging and stuff.
